### PR TITLE
Fix: 배치처리 데이터를 동적으로 변경

### DIFF
--- a/src/main/java/com/example/lachacha/global/kafka/ChatKafkaConsumer.java
+++ b/src/main/java/com/example/lachacha/global/kafka/ChatKafkaConsumer.java
@@ -2,78 +2,72 @@ package com.example.lachacha.global.kafka;
 
 
 import com.example.lachacha.global.webSocket.chats.ChatHandler;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Component
 public class ChatKafkaConsumer {
 
     private final ChatHandler chatHandler;
-    private final List<String> messageQueue = new ArrayList<>();
+    private final Queue<String> messageQueue = new ConcurrentLinkedQueue<>();
     private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
 
     public ChatKafkaConsumer(ChatHandler chatHandler) {
         this.chatHandler = chatHandler;
         startMessageProcessing();
     }
-    @KafkaListener(topics = "chat-messages", groupId = "chat-group")
-    public void listen(String payload) {
-        log.info("Kafka 메시지 수신: {}", payload);
+
+    @KafkaListener(topics = "chat-messages", groupId = "chat-group", concurrency = "6")
+    public void listen(List<String> payloads) {
+        log.info("Kafka 메시지 수신: {}", payloads.size());
         try {
-            synchronized (messageQueue) {
-                messageQueue.add(payload); // 메시지를 큐에 추가
-            }
+            messageQueue.addAll(payloads);
         } catch (Exception e) {
             log.error("Kafka 메시지 처리 중 오류 발생", e);
         }
     }
+
     private void startMessageProcessing() {
+        int queueSize = messageQueue.size();
+        int batchSize = Math.min(queueSize / 5, 20);
+        batchSize = Math.max(batchSize, 5);
+        int finalBatchSize = batchSize;
         executorService.scheduleAtFixedRate(() -> {
-            List<String> batch;
-            synchronized (messageQueue) {
-                if (messageQueue.isEmpty()) return;
-                batch = new ArrayList<>(messageQueue.subList(0, Math.min(10, messageQueue.size()))); // 최대 10개씩 처리
-                messageQueue.removeAll(batch);
+            List<String> batch = new ArrayList<>();
+            for (int i = 0; i < finalBatchSize && !messageQueue.isEmpty(); i++) {
+                batch.add(messageQueue.poll());
             }
+
+            if (batch.isEmpty()) return;
 
             for (String payload : batch) {
                 try {
                     String[] data = payload.split(":", 2);
                     Long chatRoomId = Long.parseLong(data[0]);
-                    String message = data[1];
+                    String message = filterProfanity(data[1]);
 
-                    String filteredMessage = filterProfanity(message);
-
-                    // 기존 chatHandler로 메시지 전송
-                    chatHandler.broadcastMessage(chatRoomId, filteredMessage);
-                    Thread.sleep(100); // 100ms 딜레이 추가
+                    chatHandler.broadcastMessage(chatRoomId, message);
                 } catch (Exception e) {
                     log.error("메시지 처리 중 오류 발생", e);
                 }
             }
-        }, 0,800, TimeUnit.MILLISECONDS); // 200ms마다 실행
+        }, 0, 850, TimeUnit.MILLISECONDS);
     }
 
-    private String filterProfanity(String message) {
-        // 욕설 리스트
-        List<String> profanityList = Arrays.asList("시발", "개새끼", "병신"); // 실제 욕설 리스트
+    private static final Pattern PROFANITY_PATTERN = Pattern.compile("시발|개새끼|병신");
 
-        // 욕설이 포함된 메시지를 필터링
-        for (String profanity : profanityList) {
-            if (message.contains(profanity)) {
-                message = message.replaceAll(profanity, "*".repeat(profanity.length())); // 욕설을 ***로 교체
-            }
-        }
-        return message;
+    private String filterProfanity(String message) {
+        return PROFANITY_PATTERN.matcher(message).replaceAll(match -> "*".repeat(match.group().length()));
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #이슈번호
https://github.com/uratchacha/backend/issues/26
## 📍주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.

기존에는 처리해야 할 작업을 고정으로 10개로 했다면
지금은 큐에 처리해야 할 작업을 동적으로 5~20개로 변경하였습니다
추가로 chat-messgae 파티션과 컨슈머를 6개로 나누었습니다. 
## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.