### PR TITLE
FIX: 카프카 배치처리 주기 변경

### DIFF
--- a/src/main/java/com/example/lachacha/global/kafka/ChatKafkaConsumer.java
+++ b/src/main/java/com/example/lachacha/global/kafka/ChatKafkaConsumer.java
@@ -62,7 +62,7 @@ public class ChatKafkaConsumer {
                     log.error("메시지 처리 중 오류 발생", e);
                 }
             }
-        }, 0, 850, TimeUnit.MILLISECONDS);
+        }, 0, 500, TimeUnit.MILLISECONDS);
     }
 
     private static final Pattern PROFANITY_PATTERN = Pattern.compile("시발|개새끼|병신");


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #이슈번호

## 📍주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.
500ms에서 850ms로 배치처리 주기를 바꿨더니 부하테스트에 오류랑 응답속도 성능이 횔씬 떨어지네요
다시 500ms로 바꿔서 테스트 해보겠습니다.
## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.