### PR TITLE
fix: 20개의 메시지 가져오는 걸로 변경 및 AckMode 수동 설정

### DIFF
--- a/src/main/java/com/example/lachacha/global/config/KafkaConfig.java
+++ b/src/main/java/com/example/lachacha/global/config/KafkaConfig.java
@@ -10,6 +10,7 @@ import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.listener.ContainerProperties;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +29,7 @@ public class KafkaConfig {
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, org.apache.kafka.common.serialization.StringDeserializer.class);
         config.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false); // 수동 커밋 모드
         config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 10); // 한 번에 10개의 메시지를 가져옴
+        config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 20);
         return new DefaultKafkaConsumerFactory<>(config);
     }
 
@@ -37,7 +38,8 @@ public class KafkaConfig {
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
-        factory.setBatchListener(true); // 배치 리스너 활성화
+        factory.setBatchListener(true);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);// 배치 리스너 활성화
         return factory;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
       group-id: chat-group
       auto-offset-reset: earliest
       enable-auto-commit: false
-      max-poll-records: 10 # 한 번에 최대 10개의 메시지 가져오기
+      max-poll-records: 20 # 한 번에 최대 10개의 메시지 가져오기
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #이슈번호

## 📍주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.

10개 메시지를 배치처리로 가져오는 것에서 20개로 수정하였습니다.
AckMode 수동 설정 추가하였습니다.

## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.